### PR TITLE
Fix init_epoll usage. Return value 0 indicates no error.

### DIFF
--- a/src/mcp23s17.c
+++ b/src/mcp23s17.c
@@ -189,7 +189,7 @@ int mcp23s17_wait_for_interrupt(int timeout)
     int num_fds = -1;
 
     if (epoll_fd <= 0) {
-        if (!init_epoll()) {
+        if (init_epoll() != 0) {
             return -1;
         }
     }


### PR DESCRIPTION
It seems that when 'fixed issue #5 - interrupt bug.' was incorrectly merges.

This commit fixes'mcp23s17_wait_for_interrupt' so it correctly tests for an error or no error in the return value epoll_init. 
